### PR TITLE
Refactor/no animation interact crash

### DIFF
--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -115,6 +115,10 @@ defmodule RGBMatrix.Engine do
   end
 
   @impl true
+  def handle_info(:render, %{animation: nil} = state) do
+    {:noreply, state}
+  end
+
   def handle_info(:render, state) do
     {render_in, new_colors, animation} = Animation.render(state.animation)
 
@@ -144,6 +148,15 @@ defmodule RGBMatrix.Engine do
   end
 
   @impl GenServer
+  def handle_cast({:set_animation, nil}, state) do
+    state =
+      %State{state | animation: nil, last_frame: %{}}
+      |> cancel_timer()
+      # |> schedule_next_render(0)
+
+    {:noreply, state}
+  end
+
   def handle_cast({:set_animation, animation}, state) do
     state =
       %State{state | animation: animation, last_frame: %{}}
@@ -153,6 +166,10 @@ defmodule RGBMatrix.Engine do
   end
 
   @impl GenServer
+  def handle_cast({:interact, _led}, %{animation: nil} = state) do
+    {:noreply, state}
+  end
+
   def handle_cast({:interact, led}, state) do
     {render_in, animation} = Animation.interact(state.animation, led)
 

--- a/lib/rgb_matrix/engine.ex
+++ b/lib/rgb_matrix/engine.ex
@@ -152,7 +152,6 @@ defmodule RGBMatrix.Engine do
     state =
       %State{state | animation: nil, last_frame: %{}}
       |> cancel_timer()
-      # |> schedule_next_render(0)
 
     {:noreply, state}
   end

--- a/test/rgb_matrix/engine_test.exs
+++ b/test/rgb_matrix/engine_test.exs
@@ -18,6 +18,10 @@ defmodule RGBMatrix.EngineTest do
     assert Engine.set_animation(animation) == :ok
   end
 
+  test "can set no animation" do
+    assert Engine.set_animation(nil) == :ok
+  end
+
   setup :set_animation
 
   test "can register a paintable function", %{
@@ -48,6 +52,15 @@ defmodule RGBMatrix.EngineTest do
       interaction = hd(leds)
       assert Engine.interact(interaction) == :ok
       assert_receive {:interact, ^interaction}
+    end
+
+    test "interact with no active animation", %{
+      leds: leds,
+    } do
+      :ok = Engine.set_animation(nil)
+      interaction = hd(leds)
+
+      assert Engine.interact(interaction) == :ok
     end
   end
 


### PR DESCRIPTION
This PR should fix crashes when setting a `nil` animation and when interacting with no animation running.